### PR TITLE
Fixes for stable Rust

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Z", "polonius"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 libftdi1-sys = "0.1.0"
 
 [dev-dependencies]
-argparse = "0.2.2"
 bitreader = "0.3.1"
 bitflags = "1.0.4"
 byteorder = "1.2.6"
+clap = "2.33"

--- a/examples/mercpcl.rs
+++ b/examples/mercpcl.rs
@@ -1,5 +1,3 @@
-#![feature(nll)]
-
 extern crate clap;
 extern crate safe_ftdi as ftdi;
 extern crate bitreader;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,26 +2,26 @@ use std;
 use std::fmt;
 
 #[derive(Debug)]
-pub enum Error<'a> {
-    LibFtdi(LibFtdiError<'a>),
+pub enum Error {
+    LibFtdi(LibFtdiError),
     MallocFailure,
 }
 
 #[derive(Debug)]
-pub struct LibFtdiError<'a> {
-    err_str : &'a str,
+pub struct LibFtdiError {
+    err_str : String,
 }
 
-impl<'a> LibFtdiError<'a> {
-    pub fn new(err_str : &'a str) -> LibFtdiError<'a> {
+impl LibFtdiError {
+    pub fn new<S: Into<String>>(err_str : S) -> LibFtdiError {
         LibFtdiError {
-                err_str : err_str,
+            err_str : err_str.into(),
         }
     }
 }
 
 
-impl<'a> fmt::Display for Error<'a> {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::LibFtdi(_) => {
@@ -34,13 +34,13 @@ impl<'a> fmt::Display for Error<'a> {
     }
 }
 
-impl<'a> fmt::Display for LibFtdiError<'a> {
+impl fmt::Display for LibFtdiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.err_str)
     }
 }
 
-impl<'a> std::error::Error for Error<'a> {
+impl std::error::Error for Error {
     fn cause(&self) -> Option<&std::error::Error> {
         match *self {
             Error::LibFtdi(ref ftdi_err) => {
@@ -53,4 +53,4 @@ impl<'a> std::error::Error for Error<'a> {
     }
 }
 
-impl<'a> std::error::Error for LibFtdiError<'a> {}
+impl std::error::Error for LibFtdiError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub struct Context<'a> {
     _dummy: PhantomData<&'a mut ftdic::ftdi_context>
 }
 
-pub type Result<'a, T> = result::Result<T, error::Error<'a>>;
+pub type Result<T> = result::Result<T, error::Error>;
 
 impl<'a> Context<'a> {
     fn check_ftdi_error<T>(&self, rc : raw::c_int, ok_val : T) -> Result<T> {
@@ -36,7 +36,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub fn new() -> Result<'a, Context<'a>> {
+    pub fn new() -> Result<Context<'a>> {
         let ctx = unsafe { ftdic::ftdi_new() };
 
         if ctx.is_null() {
@@ -96,7 +96,7 @@ impl<'a> Context<'a> {
         self.check_ftdi_error(rc, rc as u32)
     }
 
-    pub fn write_data<'b, 'c>(&'b self, data : &'c [u8]) -> Result<'b, u32> {
+    pub fn write_data<'b>(&self, data : &'b [u8]) -> Result<u32> {
         let raw_ptr = data.as_ptr();
         let raw_len = data.len() as i32;
 


### PR DESCRIPTION
I got a lot of test errors with the base patch (Add PhantomData field to Context struct). Most of them are from trying to reference the `LibFtdiError` type, which contains a borrow that lives for the same lifetime as `Context`. This has several implications, including being unable to do sane error handling while mutably and immutably borrowing `Context`. This patch fixes it by replacing the `&'a str` with an owned `String`. This allows the safe API to operate as intended, and fixes a hairy soundness issue.

I also had to replace `argparse`, because it keeps the mutable reference alive under modern `nll` and causes further mutable aliasing.

Finally, I removed the old `-Z polonius` build flag and `nll` feature. Everything compiles on stable Rust now! :tada: